### PR TITLE
Make `group` Parameter Optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Make `group` Parameter Optional ([#38](https://github.com/vbrandl/sablier-proxy/pull/38)) thanks to @BUR4KBEY
+
 ### Dependencies
 - Bump `anyhow` from 1.0.89 to 1.0.97 ([#5](https://github.com/vbrandl/sablier-proxy/pull/5), [#6](https://github.com/vbrandl/sablier-proxy/pull/6), [#11](https://github.com/vbrandl/sablier-proxy/pull/11), [#12](https://github.com/vbrandl/sablier-proxy/pull/12), [#17](https://github.com/vbrandl/sablier-proxy/pull/17), [#21](https://github.com/vbrandl/sablier-proxy/pull/21), [#27](https://github.com/vbrandl/sablier-proxy/pull/27), [#32](https://github.com/vbrandl/sablier-proxy/pull/32))
 - Bump `tokio` from 1.40.0 to 1.44.1 ([#7](https://github.com/vbrandl/sablier-proxy/pull/7), [#13](https://github.com/vbrandl/sablier-proxy/pull/13), [#18](https://github.com/vbrandl/sablier-proxy/pull/18), [#26](https://github.com/vbrandl/sablier-proxy/pull/26), [#34](https://github.com/vbrandl/sablier-proxy/pull/34), [#37](https://github.com/vbrandl/sablier-proxy/pull/37))

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,9 +59,9 @@ impl Config {
     pub async fn request(&self) -> Result<Response> {
         let client = Client::new();
         let url = format!("{}{API_PATH}", self.normalize_sablier_url());
-        let mut request = client.get(url).query(&[
-            ("session_duration", &self.session_duration)
-        ]);
+        let mut request = client
+            .get(url)
+            .query(&[("session_duration", &self.session_duration)]);
         if let Some(names) = &self.names {
             let names: Vec<_> = names.split(',').map(str::trim).collect();
             request = request.query(&[("names", &names)]);

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ pub struct Config {
     #[serde(default = "default_url")]
     sablier_url: String,
     names: Option<String>,
-    group: String,
+    group: Option<String>,
     session_duration: String,
     // only blocking makes sense for TCP
     blocking_timeout: Option<String>,
@@ -60,8 +60,7 @@ impl Config {
         let client = Client::new();
         let url = format!("{}{API_PATH}", self.normalize_sablier_url());
         let mut request = client.get(url).query(&[
-            ("session_duration", &self.session_duration),
-            ("group", &self.group),
+            ("session_duration", &self.session_duration)
         ]);
         if let Some(names) = &self.names {
             let names: Vec<_> = names.split(',').map(str::trim).collect();
@@ -69,6 +68,9 @@ impl Config {
         }
         if let Some(timeout) = &self.blocking_timeout {
             request = request.query(&[("timeout", &timeout)]);
+        }
+        if let Some(group) = &self.group {
+            request = request.query(&[("group", &group)]);
         }
         Ok(request.send().await?)
     }


### PR DESCRIPTION
# Make `group` Parameter Optional

## Description
This PR changes the `group` parameter from required to optional to align with the official Traefik plugin implementation.

## Motivation
When examining the official Traefik plugin implementation for Sablier, it's clear that the `group` query parameter is designed to be optional, not required:
```go
if c.Group != "" {
    q.Add("group", c.Group)
}
```
[Source](https://github.com/sablierapp/sablier/blob/cc23853966a1f92578ace0284f654fbf1ba2e746/plugins/traefik/config.go#L161C1-L163C3)

The current implementation in the codebase forces developers to specify the `group` parameter even when they don't need it, creating an unnecessary restriction not present in the official plugin.

## Changes
- Modified the config and request builder to make the `group` parameter optional